### PR TITLE
Fix inverted conditions in DateSpecifier

### DIFF
--- a/Source/NLedger/Times/DateSpecifier.cs
+++ b/Source/NLedger/Times/DateSpecifier.cs
@@ -27,11 +27,11 @@ namespace NLedger.Times
 
         public DateSpecifier (Date date, DateTraits? traits = null)
         {
-            if (traits != null && traits.Value.HasYear)
+            if (traits == null || traits.Value.HasYear)
                 Year = date.Year;
-            if (traits != null && traits.Value.HasMonth)
+            if (traits == null || traits.Value.HasMonth)
                 Month = (MonthEnum)date.Month;
-            if (traits != null && traits.Value.HasDay)
+            if (traits == null || traits.Value.HasDay)
                 Day = date.Day;
         }
 


### PR DESCRIPTION
The conditions in the `DateSpecifier` constructor are inverted, causing queries such as `--begin 'since 7 days ago' reg` to be filtered incorrectly. When the traits are null (or omitted), the intention is to include every component of the date, but currently no components are used.
In the [original source](https://github.com/ledger/ledger/blob/master/src/times.h#L266), the conditions are different:

```c++
  date_specifier_t(const date_t& date,
                   const optional<date_traits_t>& traits = none) {
    if (! traits || traits->has_year)
      year = date.year();
    if (! traits || traits->has_month)
      month = date.month();
    if (! traits || traits->has_day)
      day = date.day();

    TRACE_CTOR(date_specifier_t, "date_t, date_traits_t");
  }
```

This fix inverts the logic to match the original source code, and makes the above query work as intended.